### PR TITLE
fix: Correct warning log level name

### DIFF
--- a/docs/stable/operations_manual/logging/overview.md
+++ b/docs/stable/operations_manual/logging/overview.md
@@ -24,7 +24,7 @@ SELECT * FROM duckdb_logs;
 DuckDB supports different logging levels that control the verbosity of the logs:
 
 * `ERROR`: Only logs error messages
-* `WARNING`: Logs warnings and errors
+* `WARN`: Logs warnings and errors
 * `INFO`: Logs general information, warnings and errors (default)
 * `DEBUG`: Logs detailed debugging information
 * `TRACE`: Logs very detailed tracing information


### PR DESCRIPTION
This fixes the warning log level in the docs. To reproduce:
```
D SET logging_level = 'WARNING';
Not implemented Error:
Enum value: unrecognized value "WARNING" for enum "LogLevel"

Candidates: "WARN"
```

[Source code](https://github.com/duckdb/duckdb/blob/eae0dd31557759cc57a6a1401998e23250369fa0/src/common/enum_util.cpp#L2357):
> 		{ static_cast<uint32_t>(LogLevel::LOG_WARN), "WARN" },